### PR TITLE
Fix e2e setup hooks

### DIFF
--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -6,13 +6,17 @@ import { AppModule } from './../src/app.module';
 describe('AppController (e2e)', () => {
   let app: INestApplication;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
     }).compile();
 
     app = moduleFixture.createNestApplication();
     await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
   });
 
   it('/ (GET)', () => {

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -5,5 +5,8 @@
   "testRegex": ".e2e-spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "moduleNameMapper": {
+    "^src/(.*)$": "<rootDir>/../src/$1"
   }
 }


### PR DESCRIPTION
## Summary
- initialize the Nest app once in e2e tests
- ensure the app closes after all tests
- map `src/` paths in jest-e2e config

## Testing
- `npm run test:e2e` *(fails: Unable to connect to the database)*

------
https://chatgpt.com/codex/tasks/task_e_6849ce00f4d8832698c9eb4943d01a37